### PR TITLE
Feat: Initialize module

### DIFF
--- a/contracts/DelayModule.sol
+++ b/contracts/DelayModule.sol
@@ -45,7 +45,14 @@ contract DelayModule {
     // Mapping of approved modules
     mapping(address => bool) public modules;
 
-    bool public isInitialized = false;
+
+    constructor(     
+        Executor _executor,
+        uint256 cooldown,
+        uint256 expiration
+    ) {
+        setUp(_executor, cooldown, expiration);
+    }
 
     /// @param _executor Address of the executor (e.g. a Safe)
     /// @param cooldown Cooldown in seconds that should be required after a transaction is proposed
@@ -55,8 +62,8 @@ contract DelayModule {
         Executor _executor,
         uint256 cooldown,
         uint256 expiration
-    ) external {
-        require(!isInitialized, "Module is already initialized");
+    ) public {
+        require(address(executor) == address(0), "Module is already initialized");
         require(
             expiration == 0 || expiration >= 60,
             "Expiratition must be 0 or at least 60 seconds"
@@ -64,7 +71,6 @@ contract DelayModule {
         executor = _executor;
         txExpiration = expiration;
         txCooldown = cooldown;
-        isInitialized = true;
 
         emit DelayModuleSetup(msg.sender, address(_executor));
     }

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -15,14 +15,20 @@ The first step is to deploy the module. Every Safe will have their own module. T
 ### Deploying the module
 
 
-A hardhat task can be used to deploy a delay-module instance. This setup task requires the following parameters: `dao` (the address of the Safe). There are also optional parameters (cooldown and expiration, by default they are set to 24 hours and 7 days, respectively), for more information run `yarn hardhat setup --help`.
+Hardhat tasks can be used to deploy a delay-module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xE9E80739Af9D0DD8AaE6255c96a1266c059469ba` and the singleton of the Delay Module: `0xC67cE465f76eAa84bb7560d19F7339D1aEdA201a`.
+
+ These setup tasks requires the following parameters: `dao` (the address of the Safe). There are also optional parameters (cooldown and expiration, by default they are set to 24 hours and 7 days, respectively), for more information run `yarn hardhat setup --help` or `yarn hardhat factory-setup --help`.
 
 An example for this on Rinkeby would be:
 `yarn hardhat --network rinkeby setup --dao <safe_address>`
 
+or
+
+`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --singleton <singleton_address> --dao <safe_address>`
+
 This should return the address of the deployed delay-module. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 
-Once the module is deployed you should verify the source code. If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this.
+Once the module is deployed you should verify the source code (Note: If you used the factory deployment the contract should be already verified). If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this.
 
 An example for this on Rinkeby would be:
 `yarn hardhat --network rinkeby verifyEtherscan --module 0x4242424242424242424242424242424242424242 --dao <safe_address>`

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -15,7 +15,7 @@ The first step is to deploy the module. Every Safe will have their own module. T
 ### Deploying the module
 
 
-Hardhat tasks can be used to deploy a delay-module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xE9E80739Af9D0DD8AaE6255c96a1266c059469ba` and the singleton of the Delay Module: `0xC67cE465f76eAa84bb7560d19F7339D1aEdA201a`.
+Hardhat tasks can be used to deploy a delay-module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xd067410a85ffC8C55f7245DE4BfE16C95329D232` and the Master Copy of the Delay Module: `0x3cc7aBD1908906e2102D302249c82d083975e1EF`.
 
  These setup tasks requires the following parameters: `dao` (the address of the Safe). There are also optional parameters (cooldown and expiration, by default they are set to 24 hours and 7 days, respectively), for more information run `yarn hardhat setup --help` or `yarn hardhat factory-setup --help`.
 
@@ -24,7 +24,7 @@ An example for this on Rinkeby would be:
 
 or
 
-`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --singleton <singleton_address> --dao <safe_address>`
+`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --mastercopy <mastercopy_address> --dao <safe_address>`
 
 This should return the address of the deployed delay-module. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -1,6 +1,7 @@
 import "hardhat-deploy";
 import "@nomiclabs/hardhat-ethers";
 import { task, types } from "hardhat/config";
+import { Contract } from "ethers";
 
 task("setup", "Deploys a SafeDelay module")
     .addParam("dao", "Address of the DAO (e.g. Safe)", undefined, types.string)
@@ -13,6 +14,37 @@ task("setup", "Deploys a SafeDelay module")
         const module = await Module.deploy(taskArgs.dao, taskArgs.cooldown, taskArgs.expiration);
 
         console.log("Module deployed to:", module.address);
+    });
+
+task("factory-setup", "Deploys a SafeDelay module through a proxy")
+    .addParam("factory", "Address of the Proxy Factory", undefined, types.string)
+    .addParam("singleton", "Address of the Delay Module Master Copy", undefined, types.string)
+    .addParam("dao", "Address of the DAO (e.g. Safe)", undefined, types.string)
+    .addParam("cooldown", "Cooldown in seconds that should be required after a oracle provided answer", 24 * 3600, types.int, true)
+    .addParam("expiration", "Time duration in seconds for which a positive answer is valid. After this time the answer is expired", 7 * 24 * 3600, types.int, true)
+    .setAction(async (taskArgs, hardhatRuntime) => {
+        const [caller] = await hardhatRuntime.ethers.getSigners();
+        console.log("Using the account:", caller.address);
+
+        const FactoryAbi = [
+            `function deployModule(
+                   address singleton, 
+                   bytes memory initializer
+             ) public returns (address clone)`,
+         ];
+         
+         const Factory = new Contract(taskArgs.factory, FactoryAbi, caller)
+         const Module = await hardhatRuntime.ethers.getContractFactory("DelayModule");
+         
+         const initParams = Module.interface.encodeFunctionData('setUp', [
+            taskArgs.dao, 
+            taskArgs.cooldown,
+            taskArgs.expiration,
+        ])
+
+        const receipt = await Factory.deployModule(taskArgs.singleton, initParams).then((tx: any) => tx.wait(3));
+        console.log("Module deployed to:", receipt.logs[1].address);
+
     });
 
 task("verifyEtherscan", "Verifies the contract on etherscan")

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -3,6 +3,8 @@ import "@nomiclabs/hardhat-ethers";
 import { task, types } from "hardhat/config";
 import { Contract } from "ethers";
 
+const FIRST_ADDRESS = "0x0000000000000000000000000000000000000001";
+
 task("setup", "Deploys a SafeDelay module")
     .addParam("dao", "Address of the DAO (e.g. Safe)", undefined, types.string)
     .addParam("cooldown", "Cooldown in seconds that should be required after a oracle provided answer", 24 * 3600, types.int, true)
@@ -18,7 +20,7 @@ task("setup", "Deploys a SafeDelay module")
 
 task("factory-setup", "Deploys a SafeDelay module through a proxy")
     .addParam("factory", "Address of the Proxy Factory", undefined, types.string)
-    .addParam("singleton", "Address of the Delay Module Master Copy", undefined, types.string)
+    .addParam("mastercopy", "Address of the Delay Module Master Copy", undefined, types.string)
     .addParam("dao", "Address of the DAO (e.g. Safe)", undefined, types.string)
     .addParam("cooldown", "Cooldown in seconds that should be required after a oracle provided answer", 24 * 3600, types.int, true)
     .addParam("expiration", "Time duration in seconds for which a positive answer is valid. After this time the answer is expired", 7 * 24 * 3600, types.int, true)
@@ -28,7 +30,7 @@ task("factory-setup", "Deploys a SafeDelay module through a proxy")
 
         const FactoryAbi = [
             `function deployModule(
-                   address singleton, 
+                   address masterCopy, 
                    bytes memory initializer
              ) public returns (address clone)`,
          ];
@@ -42,7 +44,7 @@ task("factory-setup", "Deploys a SafeDelay module through a proxy")
             taskArgs.expiration,
         ])
 
-        const receipt = await Factory.deployModule(taskArgs.singleton, initParams).then((tx: any) => tx.wait(3));
+        const receipt = await Factory.deployModule(taskArgs.mastercopy, initParams).then((tx: any) => tx.wait(3));
         console.log("Module deployed to:", receipt.logs[1].address);
 
     });
@@ -60,5 +62,23 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
             ]
         })
     });
+
+
+task("deployMasterCopy", "deploy a master copy of Delay Module").setAction(
+    async (_, hardhatRuntime) => {
+        const [caller] = await hardhatRuntime.ethers.getSigners();
+        console.log("Using the account:", caller.address);
+        const Module = await hardhatRuntime.ethers.getContractFactory("DelayModule");
+        const module = await Module.deploy(FIRST_ADDRESS, 0, 0);
+    
+        await module.deployTransaction.wait(3);
+    
+        console.log("Module deployed to:", module.address);
+        await hardhatRuntime.run("verify:verify", {
+            address: module.address,
+            constructorArguments: [FIRST_ADDRESS, 0, 0]
+        });
+    }
+);
 
 export { };

--- a/test/DelayModule.spec.ts
+++ b/test/DelayModule.spec.ts
@@ -4,6 +4,7 @@ import "@nomiclabs/hardhat-ethers";
 
 const ZERO_STATE =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 describe("DelayModule", async () => {
   const baseSetup = deployments.createFixture(async () => {
@@ -18,7 +19,7 @@ describe("DelayModule", async () => {
   const setupTestWithTestExecutor = deployments.createFixture(async () => {
     const base = await baseSetup();
     const Module = await hre.ethers.getContractFactory("DelayModule");
-    const module = await Module.deploy();
+    const module = await Module.deploy(ZERO_ADDRESS, 0, "0x1337");
     await module.setUp(base.executor.address, 0, "0x1337");
     return { ...base, Module, module };
   });
@@ -28,16 +29,14 @@ describe("DelayModule", async () => {
   describe("setUp()", async () => {
     it("throws if not enough time between txCooldown and txExpiration", async () => {
       const Module = await hre.ethers.getContractFactory("DelayModule");
-      const module = await Module.deploy();
-      await expect(module.setUp(user1.address, 1, 59)).to.be.revertedWith(
+      await expect(Module.deploy(ZERO_ADDRESS, 1, 59)).to.be.revertedWith(
         "Expiratition must be 0 or at least 60 seconds"
       );
     });
 
     it("txExpiration can be 0", async () => {
       const Module = await hre.ethers.getContractFactory("DelayModule");
-      const module = await Module.deploy();
-      await module.setUp(user1.address, 1, 0);
+      await Module.deploy(user1.address, 1, 0);
     });
   });
 


### PR DESCRIPTION
Changes proposed:

- Make the Safe Delay Module initializable so we can use a Proxy Factory to deploy and initialize the module.
- Add script to deploy module with factory
- Add script to deploy Master Copy of module

The reasoning of this is that we want to create a Minimal Proxy Factory to deploy different Safe Modules and pay the minor gas possible

We are also allowing the user to deploy the module by themself and pass the parameters through the constructor - This way if the transactions through the proxy get expensive (It costs roughly 5,000 extra gas for each transaction when you use a proxy) the user will be able to use the normal deployment w/constructor