### PR TITLE
Chore: Tests for factory flow added

### DIFF
--- a/contracts/test/TestFactory.sol
+++ b/contracts/test/TestFactory.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import "@gnosis/zodiac/contracts/factory/ModuleProxyFactory.sol";

--- a/test/Delay.spec.ts
+++ b/test/Delay.spec.ts
@@ -60,15 +60,6 @@ describe("DelayModifier", async () => {
       await Module.deploy(user1.address, user1.address, 1, 0);
     });
 
-    it("throws if module has already been initialized", async () => {
-      await baseSetup();
-      const Module = await hre.ethers.getContractFactory("Delay");
-      const module = await Module.deploy(user1.address, user1.address, 1, 0);
-      await expect(module.setUp(initializeParams)).to.be.revertedWith(
-        "Modifier is already initialized"
-      );
-    });
-
     it("should emit event because of successful set up", async () => {
       const Module = await hre.ethers.getContractFactory("Delay");
       const module = await Module.deploy(user1.address, user1.address, 1, 0);

--- a/test/FactoryFriendly.spec.ts
+++ b/test/FactoryFriendly.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from "chai";
+import hre, { deployments, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AbiCoder } from "ethers/lib/utils";
+import { AddressOne } from "@gnosis.pm/safe-contracts";
+
+const FirstAddress = "0x0000000000000000000000000000000000000001";
+const saltNonce = "0xfa";
+
+describe("Module works with factory", () => {
+  const cooldown = 100
+  const expiration = 180
+  const paramsTypes = ["address", "address", "uint256", "uint256"];
+
+  const baseSetup = deployments.createFixture(async () => {
+    await deployments.fixture();
+    const Factory = await hre.ethers.getContractFactory("ModuleProxyFactory");
+    const DelayModifier = await hre.ethers.getContractFactory("Delay");
+    const factory = await Factory.deploy();
+
+    const masterCopy = await DelayModifier.deploy(
+      FirstAddress,
+      FirstAddress,
+      0,
+      0
+    );
+
+    return { factory, masterCopy };
+  });
+
+  it("should throw because master copy is already initialized", async () => {
+    const { masterCopy } = await baseSetup();
+    const encodedParams = new AbiCoder().encode(paramsTypes, [
+      AddressOne,
+      AddressOne,
+      100,
+      180,
+    ]);
+
+    await expect(masterCopy.setUp(encodedParams)).to.be.revertedWith(
+      "Modifier is already initialized"
+    );
+  });
+
+  it("should deploy new amb module proxy", async () => {
+    const { factory, masterCopy } = await baseSetup();
+    const [executor, owner] = await ethers.getSigners();
+    const paramsValues = [
+      owner.address,
+      executor.address,
+      100,
+      180,
+    ];
+    const encodedParams = [new AbiCoder().encode(paramsTypes, paramsValues)];
+    const initParams = masterCopy.interface.encodeFunctionData(
+      "setUp",
+      encodedParams
+    );
+    const receipt = await factory
+      .deployModule(masterCopy.address, initParams, saltNonce)
+      .then((tx: any) => tx.wait());
+
+    // retrieve new address from event
+    const {
+      args: [newProxyAddress],
+    } = receipt.events.find(
+      ({ event }: { event: string }) => event === "ModuleProxyCreation"
+    );
+
+    const newProxy = await hre.ethers.getContractAt(
+      "Delay",
+      newProxyAddress
+    );
+    expect(await newProxy.txCooldown()).to.be.eq(cooldown);
+    expect(await newProxy.txExpiration()).to.be.eq(expiration);
+  });
+});


### PR DESCRIPTION
Changes proposed on this PR:
- Added a new file which is called `FactoryFriendly.spec.ts` and two tests cases has been added:
   1. Make sure that the module is deployed through factory and have the expected params
   2. MasterCopy can not be initialized twice
- Created test contract to import `ModuleProxyFactory` - Can not import it in the same file as `Imports` because the `Mock` contracts are `0.6` and it has a version compatibility with `0.8`