### PR TITLE
Feat: Deployment tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ env/
 .env
 .history
 coverage*
+deployments

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -64,3 +64,7 @@ event TransactionAdded(
 ```
 
 There are different services available for this such as the [OpenZepplin Defender Sentinel](https://docs.openzeppelin.com/defender/sentinel).
+
+
+### Deploy a caster copy
+The master copy contracts can be deployed through `yarn deploy` command. Note that this only should be done if the Delay Modifier contracts gets an update and the ones referred on the (zodiac repository)[https://github.com/gnosis/zodiac/blob/master/src/factory/constants.ts] should be used.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "hardhat compile",
     "test": "hardhat test",
+    "deploy": "hardhat deploy --network",
     "coverage": "hardhat coverage",
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint 'contracts/**/*.sol'",

--- a/src/deploy/deploy_module.ts
+++ b/src/deploy/deploy_module.ts
@@ -1,0 +1,26 @@
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const FirstAddress = "0x0000000000000000000000000000000000000001";
+
+const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deployer } = await getNamedAccounts();
+  const { deploy } = deployments;
+  const args = [
+    FirstAddress,
+    FirstAddress,
+    0,
+    0
+  ];
+
+  await deploy("Delay", {
+    from: deployer,
+    args,
+    log: true,
+    deterministicDeployment: true,
+  });
+};
+
+deploy.tags = ["delay-modifier"];
+export default deploy;

--- a/src/deploy/verify.ts
+++ b/src/deploy/verify.ts
@@ -1,0 +1,32 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { TASK_ETHERSCAN_VERIFY } from "hardhat-deploy";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { run } = hre;
+  if (!["rinkeby", "mainnet"].includes(hre.network.name)) {
+    return;
+  }
+
+  if (!process.env.INFURA_KEY) {
+    console.log(
+      `Could not find Infura key in env, unable to connect to network ${hre.network.name}`
+    );
+    return;
+  }
+
+  console.log("Verification of Delay Modifier in etherscan...");
+  console.log("Waiting for 1 minute before verifying contracts...");
+  // Etherscan needs some time to process before trying to verify.
+  await new Promise((resolve) => setTimeout(resolve, 60000));
+
+  console.log("Starting to verify now");
+
+  await run(TASK_ETHERSCAN_VERIFY, {
+    apiKey: process.env.ETHERSCAN_KEY_API,
+    license: "GPL-3.0",
+    solcInput: true,
+    forceLicense: true, // we need this because contracts license is LGPL-3.0-only
+  });
+};
+export default func;

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -71,22 +71,4 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
         })
     });
 
-
-task("deployMasterCopy", "deploy a master copy of Delay Modifier").setAction(
-    async (_, hardhatRuntime) => {
-        const [caller] = await hardhatRuntime.ethers.getSigners();
-        console.log("Using the account:", caller.address);
-        const Modifier = await hardhatRuntime.ethers.getContractFactory("Delay");
-        const modifier = await Modifier.deploy(FirstAddress, FirstAddress, 0, 0);
-    
-        await modifier.deployTransaction.wait(3);
-    
-        console.log("Modifier deployed to:", modifier.address);
-        await hardhatRuntime.run("verify", {
-            address: modifier.address,
-            constructorArguments: [FirstAddress, FirstAddress, "0", "0"]
-        });
-    }
-);
-
 export { };


### PR DESCRIPTION
Changes proposed on this PR:
- Hardhat deploy is now being used to deploy master copy contracts, and verify them on etherscan
- Removed `deployMasterCopy` task from `src/setup.ts` file
- Documentation updated accordingly