### PR TITLE
Chore: Change of variable name executor to avatar

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,5 @@
 module.exports = {
-    skipFiles: ['test/Imports.sol', 'test/TestExecutor.sol', 'test/Mock.sol'],
+    skipFiles: ['test/Imports.sol', 'test/TestAvatar.sol', 'test/Mock.sol'],
     mocha: {
         grep: "@skip-on-coverage", // Find everything with this tag
         invert: true               // Run the grep's inverse set.

--- a/contracts/Delay.sol
+++ b/contracts/Delay.sol
@@ -24,19 +24,19 @@ contract Delay is Modifier {
     mapping(uint256 => uint256) public txCreatedAt;
 
     /// @param _owner Address of the owner
-    /// @param _executor Address of the executor (e.g. a Safe)
+    /// @param _avatar Address of the avatar (e.g. a Safe)
     /// @param _cooldown Cooldown in seconds that should be required after a transaction is proposed
     /// @param _expiration Duration that a proposed transaction is valid for after the cooldown, in seconds (or 0 if valid forever)
     /// @notice There need to be at least 60 seconds between end of cooldown and expiration
     constructor(
         address _owner,
-        address _executor,
+        address _avatar,
         uint256 _cooldown,
         uint256 _expiration
     ) {
         bytes memory initParams = abi.encode(
             _owner,
-            _executor,
+            _avatar,
             _cooldown,
             _expiration
         );
@@ -46,18 +46,18 @@ contract Delay is Modifier {
     function setUp(bytes memory initParams) public override {
         (
             address _owner,
-            address _executor,
+            address _avatar,
             uint256 _cooldown,
             uint256 _expiration
         ) = abi.decode(initParams, (address, address, uint256, uint256));
         require(!initialized, "Modifier is already initialized");
-        require(_executor != address(0), "Executor can not be zero address");
+        require(_avatar != address(0), "Avatar can not be zero address");
         require(
             _expiration == 0 || _expiration >= 60,
             "Expiratition must be 0 or at least 60 seconds"
         );
 
-        avatar = _executor;
+        avatar = _avatar;
         txExpiration = _expiration;
         txCooldown = _cooldown;
 
@@ -66,7 +66,7 @@ contract Delay is Modifier {
         setupModules();
         initialized = true;
 
-        emit DelaySetup(msg.sender, _executor);
+        emit DelaySetup(msg.sender, _avatar);
     }
 
     function setupModules() internal {
@@ -79,7 +79,7 @@ contract Delay is Modifier {
 
     /// @dev Sets the cooldown before a transaction can be executed.
     /// @param cooldown Cooldown in seconds that should be required before the transaction can be executed
-    /// @notice This can only be called by the executor
+    /// @notice This can only be called by the avatar
     function setTxCooldown(uint256 cooldown) public onlyOwner {
         txCooldown = cooldown;
     }
@@ -87,7 +87,7 @@ contract Delay is Modifier {
     /// @dev Sets the duration for which a transaction is valid.
     /// @param expiration Duration that a transaction is valid in seconds (or 0 if valid forever) after the cooldown
     /// @notice There need to be at least 60 seconds between end of cooldown and expiration
-    /// @notice This can only be called by the executor
+    /// @notice This can only be called by the avatar
     function setTxExpiration(uint256 expiration) public onlyOwner {
         require(
             expiration == 0 || expiration >= 60,
@@ -98,7 +98,7 @@ contract Delay is Modifier {
 
     /// @dev Sets transaction nonce. Used to invalidate or skip transactions in queue.
     /// @param _nonce New transaction nonce
-    /// @notice This can only be called by the executor
+    /// @notice This can only be called by the avatar
     function setTxNonce(uint256 _nonce) public onlyOwner {
         require(
             _nonce > txNonce,
@@ -108,7 +108,7 @@ contract Delay is Modifier {
         txNonce = _nonce;
     }
 
-    /// @dev Adds a transaction to the queue (same as executor interface so that this can be placed between other modules and the safe).
+    /// @dev Adds a transaction to the queue (same as avatar interface so that this can be placed between other modules and the safe).
     /// @param to Destination address of module transaction
     /// @param value Ether value of module transaction
     /// @param data Data payload of module transaction

--- a/contracts/test/TestAvatar.sol
+++ b/contracts/test/TestAvatar.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0;
 
-contract TestExecutor {
+contract TestAvatar {
     address public module;
 
     receive() external payable {}

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -10,7 +10,7 @@ For the hardhat tasks to work the environment needs to be properly configured. S
 
 ## Setting up the modifier
 
-The first step is to deploy the modifier. Every Safe will have their own modifier. The modifier is linked to a Safe (called owner in the contract). Only the owner can change the state of the modifier. The modifier is linked to an executor which takes care of executing the transactions.
+The first step is to deploy the modifier. Every Safe will have their own modifier. The modifier is linked to a Safe (called owner in the contract). Only the owner can change the state of the modifier. The modifier is linked to an avatar which takes care of executing the transactions.
 
 ### Deploying the modifier
 
@@ -18,7 +18,7 @@ Hardhat tasks can be used to deploy a Delay Modifier instance. There are two dif
 
 These setup tasks requires the following parameters:
 
-- `executor` - the address of the executor.
+- `avatar` - the address of the avatar.
 - `owner` - the address of the owner
 - `cooldown` - optional, by default is set to 24 hours
 - `expiration` - optional, by default is set to 7 days
@@ -26,18 +26,18 @@ These setup tasks requires the following parameters:
 For more information run `yarn hardhat setup --help` or `yarn hardhat factorySetup --help`.
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby setup --owner <owner_address> --executor <executor_address>`
+`yarn hardhat --network rinkeby setup --owner <owner_address> --avatar <avatar_address>`
 
 or
 
-`yarn hardhat --network rinkeby factorySetup --factory <factory_address> --mastercopy <mastercopy_address> --owner <owner_address> --executor <executor_address>`
+`yarn hardhat --network rinkeby factorySetup --factory <factory_address> --mastercopy <mastercopy_address> --owner <owner_address> --avatar <avatar_address>`
 
 This should return the address of the deployed Delay modifier. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 
 Once the modifier is deployed you should verify the source code (Note: If you used the factory deployment the contract should be already verified). If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this.
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby verifyEtherscan --modifier 0x4242424242424242424242424242424242424242 --owner <owner_address> --executor <executor_address>`
+`yarn hardhat --network rinkeby verifyEtherscan --modifier 0x4242424242424242424242424242424242424242 --owner <owner_address> --avatar <avatar_address>`
 
 ### Enabling the modifier
 

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -8,14 +8,14 @@ const FirstAddress = "0x0000000000000000000000000000000000000001";
 
 task("setup", "Deploys a SafeDelay modifier")
     .addParam("owner", "Address of the owner", undefined, types.string)
-    .addParam("executor", "Address of the executor (e.g. Safe)", undefined, types.string)
+    .addParam("avatar", "Address of the avatar (e.g. Safe)", undefined, types.string)
     .addParam("cooldown", "Cooldown in seconds that should be required after a oracle provided answer", 24 * 3600, types.int, true)
     .addParam("expiration", "Time duration in seconds for which a positive answer is valid. After this time the answer is expired", 7 * 24 * 3600, types.int, true)
     .setAction(async (taskArgs, hardhatRuntime) => {
         const [caller] = await hardhatRuntime.ethers.getSigners();
         console.log("Using the account:", caller.address);
         const Modifier = await hardhatRuntime.ethers.getContractFactory("Delay");
-        const modifier = await Modifier.deploy(taskArgs.owner, taskArgs.executor, taskArgs.cooldown, taskArgs.expiration);
+        const modifier = await Modifier.deploy(taskArgs.owner, taskArgs.avatar, taskArgs.cooldown, taskArgs.expiration);
 
         console.log("Modifier deployed to:", modifier.address);
     });
@@ -24,7 +24,7 @@ task("factorySetup", "Deploys a SafeDelay modifier through a proxy")
     .addParam("factory", "Address of the Proxy Factory", undefined, types.string)
     .addParam("mastercopy", "Address of the Delay Modifier Master Copy", undefined, types.string)
     .addParam("owner", "Address of the owner", undefined, types.string)
-    .addParam("executor", "Address of the executor (e.g. Safe)", undefined, types.string)
+    .addParam("avatar", "Address of the avatar (e.g. Safe)", undefined, types.string)
     .addParam("cooldown", "Cooldown in seconds that should be required after a oracle provided answer", 24 * 3600, types.int, true)
     .addParam("expiration", "Time duration in seconds for which a positive answer is valid. After this time the answer is expired", 7 * 24 * 3600, types.int, true)
     .setAction(async (taskArgs, hardhatRuntime) => {
@@ -45,7 +45,7 @@ task("factorySetup", "Deploys a SafeDelay modifier through a proxy")
              ["address", "address", "uint256", "uint256"],
              [
                 taskArgs.owner,
-                taskArgs.executor, 
+                taskArgs.avatar, 
                 taskArgs.cooldown,
                 taskArgs.expiration,
              ]
@@ -59,14 +59,14 @@ task("factorySetup", "Deploys a SafeDelay modifier through a proxy")
 task("verifyEtherscan", "Verifies the contract on etherscan")
     .addParam("modifier", "Address of the modifier", undefined, types.string)
     .addParam("owner", "Address of the owner", undefined, types.string)
-    .addParam("executor", "Address of the executor (e.g. Safe)", undefined, types.string)
+    .addParam("avatar", "Address of the avatar (e.g. Safe)", undefined, types.string)
     .addParam("cooldown", "Cooldown in seconds that should be required after a oracle provided answer", 24 * 3600, types.int, true)
     .addParam("expiration", "Time duration in seconds for which a positive answer is valid. After this time the answer is expired", 7 * 24 * 3600, types.int, true)
     .setAction(async (taskArgs, hardhatRuntime) => {
         await hardhatRuntime.run("verify", {
             address: taskArgs.modifier,
             constructorArgsParams: [
-                taskArgs.owner, taskArgs.executor, `${taskArgs.cooldown}`, `${taskArgs.expiration}`
+                taskArgs.owner, taskArgs.avatar, `${taskArgs.cooldown}`, `${taskArgs.expiration}`
             ]
         })
     });

--- a/test/Delay.spec.ts
+++ b/test/Delay.spec.ts
@@ -13,25 +13,25 @@ describe("DelayModifier", async () => {
 
   const baseSetup = deployments.createFixture(async () => {
     await deployments.fixture();
-    const Executor = await hre.ethers.getContractFactory("TestExecutor");
-    const executor = await Executor.deploy();
+    const Avatar = await hre.ethers.getContractFactory("TestAvatar");
+    const avatar = await Avatar.deploy();
     const Mock = await hre.ethers.getContractFactory("MockContract");
     const mock = await Mock.deploy();
 
     initializeParams = new AbiCoder().encode(
       ["address", "address", "uint256", "uint256"],
-      [executor.address, executor.address, 0, "0x1337"]
+      [avatar.address, avatar.address, 0, "0x1337"]
     );
 
-    return { Executor, executor, mock };
+    return { Avatar, avatar, mock };
   });
 
-  const setupTestWithTestExecutor = deployments.createFixture(async () => {
+  const setupTestWithTestAvatar = deployments.createFixture(async () => {
     const base = await baseSetup();
     const Modifier = await hre.ethers.getContractFactory("Delay");
     const modifier = await Modifier.deploy(
-      base.executor.address,
-      base.executor.address,
+      base.avatar.address,
+      base.avatar.address,
       0,
       "0x1337"
     );
@@ -48,11 +48,11 @@ describe("DelayModifier", async () => {
       ).to.be.revertedWith("Expiratition must be 0 or at least 60 seconds");
     });
 
-    it("throws if executor is zero address", async () => {
+    it("throws if avatar is zero address", async () => {
       const Module = await hre.ethers.getContractFactory("Delay");
       await expect(
         Module.deploy(ZeroAddress, ZeroAddress, 1, 0)
-      ).to.be.revertedWith("Executor can not be zero address");
+      ).to.be.revertedWith("Avatar can not be zero address");
     });
 
     it("txExpiration can be 0", async () => {
@@ -79,36 +79,36 @@ describe("DelayModifier", async () => {
 
   describe("disableModule()", async () => {
     it("throws if not authorized", async () => {
-      const { modifier } = await setupTestWithTestExecutor();
+      const { modifier } = await setupTestWithTestAvatar();
       await expect(
         modifier.disableModule(FirstAddress, user1.address)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("throws if module is null or sentinel", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const disable = await modifier.populateTransaction.disableModule(
         FirstAddress,
         FirstAddress
       );
       await expect(
-        executor.exec(modifier.address, 0, disable.data)
+        avatar.exec(modifier.address, 0, disable.data)
       ).to.be.revertedWith("Invalid module");
     });
 
     it("throws if module is not added ", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const disable = await modifier.populateTransaction.disableModule(
         ZeroAddress,
         user1.address
       );
       await expect(
-        executor.exec(modifier.address, 0, disable.data)
+        avatar.exec(modifier.address, 0, disable.data)
       ).to.be.revertedWith("Module already disabled");
     });
 
     it("disables a module()", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const enable = await modifier.populateTransaction.enableModule(
         user1.address
       );
@@ -117,11 +117,11 @@ describe("DelayModifier", async () => {
         user1.address
       );
 
-      await executor.exec(modifier.address, 0, enable.data);
+      await avatar.exec(modifier.address, 0, enable.data);
       await expect(await modifier.isModuleEnabled(user1.address)).to.be.equals(
         true
       );
-      await executor.exec(modifier.address, 0, disable.data);
+      await avatar.exec(modifier.address, 0, disable.data);
       await expect(await modifier.isModuleEnabled(user1.address)).to.be.equals(
         false
       );
@@ -130,42 +130,42 @@ describe("DelayModifier", async () => {
 
   describe("enableModule()", async () => {
     it("throws if not authorized", async () => {
-      const { modifier } = await setupTestWithTestExecutor();
+      const { modifier } = await setupTestWithTestAvatar();
       await expect(modifier.enableModule(user1.address)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("throws because module is already enabled", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const enable = await modifier.populateTransaction.enableModule(
         user1.address
       );
 
-      await executor.exec(modifier.address, 0, enable.data);
+      await avatar.exec(modifier.address, 0, enable.data);
       await expect(
-        executor.exec(modifier.address, 0, enable.data)
+        avatar.exec(modifier.address, 0, enable.data)
       ).to.be.revertedWith("Module already enabled");
     });
 
     it("throws because module is invalid ", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const enable = await modifier.populateTransaction.enableModule(
         FirstAddress
       );
 
       await expect(
-        executor.exec(modifier.address, 0, enable.data)
+        avatar.exec(modifier.address, 0, enable.data)
       ).to.be.revertedWith("Invalid module");
     });
 
     it("enables a module", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const enable = await modifier.populateTransaction.enableModule(
         user1.address
       );
 
-      await executor.exec(modifier.address, 0, enable.data);
+      await avatar.exec(modifier.address, 0, enable.data);
       await expect(await modifier.isModuleEnabled(user1.address)).to.be.equals(
         true
       );
@@ -177,19 +177,19 @@ describe("DelayModifier", async () => {
 
   describe("setTxCooldown()", async () => {
     it("throws if not authorized", async () => {
-      const { modifier } = await setupTestWithTestExecutor();
+      const { modifier } = await setupTestWithTestAvatar();
       await expect(modifier.setTxCooldown(42)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("sets cooldown", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.setTxCooldown(43);
       let cooldown = await modifier.txCooldown();
 
       await expect(cooldown._hex).to.be.equals("0x00");
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
       cooldown = await modifier.txCooldown();
       await expect(cooldown._hex).to.be.equals("0x2b");
     });
@@ -197,28 +197,28 @@ describe("DelayModifier", async () => {
 
   describe("setTxExpiration()", async () => {
     it("throws if not authorized", async () => {
-      const { modifier } = await setupTestWithTestExecutor();
+      const { modifier } = await setupTestWithTestAvatar();
       await expect(modifier.setTxExpiration(42)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("thows if expiration is less than 60 seconds.", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.setTxExpiration(59);
 
       await expect(
-        executor.exec(modifier.address, 0, tx.data)
+        avatar.exec(modifier.address, 0, tx.data)
       ).to.be.revertedWith("Expiratition must be 0 or at least 60 seconds");
     });
 
     it("sets expiration", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.setTxExpiration("0x031337");
       let expiration = await modifier.txExpiration();
 
       await expect(expiration._hex).to.be.equals("0x1337");
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
       expiration = await modifier.txExpiration();
       await expect(expiration._hex).to.be.equals("0x031337");
     });
@@ -226,45 +226,45 @@ describe("DelayModifier", async () => {
 
   describe("setTxNonce()", async () => {
     it("throws if not authorized", async () => {
-      const { modifier } = await setupTestWithTestExecutor();
+      const { modifier } = await setupTestWithTestAvatar();
       await expect(modifier.setTxNonce(42)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("thows if nonce is less than current nonce.", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.setTxExpiration(60);
       const tx2 = await modifier.populateTransaction.setTxNonce(0);
-      await expect(executor.exec(modifier.address, 0, tx.data));
+      await expect(avatar.exec(modifier.address, 0, tx.data));
 
       await expect(
-        executor.exec(modifier.address, 0, tx2.data)
+        avatar.exec(modifier.address, 0, tx2.data)
       ).to.be.revertedWith("New nonce must be higher than current txNonce");
     });
 
     it("thows if nonce is more than queueNonce + 1.", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
       const tx2 = await modifier.populateTransaction.setTxNonce(42);
-      await expect(executor.exec(modifier.address, 0, tx.data));
+      await expect(avatar.exec(modifier.address, 0, tx.data));
       await modifier.execTransactionFromModule(user1.address, 0, "0x", 0);
 
       await expect(
-        executor.exec(modifier.address, 0, tx2.data)
+        avatar.exec(modifier.address, 0, tx2.data)
       ).to.be.revertedWith("Cannot be higher than queueNonce");
     });
 
     it("sets nonce", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
       const tx2 = await modifier.populateTransaction.setTxNonce(1);
       let txNonce = await modifier.txNonce();
 
       await expect(txNonce._hex).to.be.equals("0x00");
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
       await modifier.execTransactionFromModule(user1.address, 0, "0x", 0);
-      await expect(executor.exec(modifier.address, 0, tx2.data));
+      await expect(avatar.exec(modifier.address, 0, tx2.data));
       txNonce = await modifier.txNonce();
       await expect(txNonce._hex).to.be.equals("0x01");
     });
@@ -272,16 +272,16 @@ describe("DelayModifier", async () => {
 
   describe("execTransactionFromModule()", async () => {
     it("throws if not authorized", async () => {
-      const { modifier } = await setupTestWithTestExecutor();
+      const { modifier } = await setupTestWithTestAvatar();
       await expect(
         modifier.execTransactionFromModule(user1.address, 0, "0x", 0)
       ).to.be.revertedWith("Module not authorized");
     });
 
     it("increments queueNonce", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
       let queueNonce = await modifier.queueNonce();
 
       await expect(queueNonce._hex).to.be.equals("0x00");
@@ -291,9 +291,9 @@ describe("DelayModifier", async () => {
     });
 
     it("sets txHash", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
       let txHash = await modifier.getTransactionHash(user1.address, 0, "0x", 0);
 
@@ -303,10 +303,10 @@ describe("DelayModifier", async () => {
     });
 
     it("sets txCreatedAt", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
       let expectedTimestamp = await modifier.getTxCreatedAt(0);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
       await expect(expectedTimestamp._hex).to.be.equals("0x00");
       let receipt = await modifier.execTransactionFromModule(
@@ -327,9 +327,9 @@ describe("DelayModifier", async () => {
     });
 
     it("emits transaction details", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
       const expectedQueueNonce = await modifier.queueNonce;
 
       await expect(
@@ -349,9 +349,9 @@ describe("DelayModifier", async () => {
 
   describe("executeNextTx()", async () => {
     it("throws if there is nothing in queue", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
       await expect(
         modifier.executeNextTx(user1.address, 42, "0x", 0)
@@ -359,12 +359,12 @@ describe("DelayModifier", async () => {
     });
 
     it("throws if cooldown has not passed", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       let tx = await modifier.populateTransaction.setTxCooldown(42);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
       tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
       await modifier.execTransactionFromModule(user1.address, 42, "0x", 0);
       await expect(
@@ -373,11 +373,11 @@ describe("DelayModifier", async () => {
     });
 
     it("throws if transaction has expired", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
-      await executor.setModule(modifier.address);
+      await avatar.setModule(modifier.address);
       await modifier.execTransactionFromModule(user1.address, 0, "0x", 0);
       let expiry = await modifier.txCreatedAt(0);
       await hre.network.provider.send("evm_setNextBlockTimestamp", [
@@ -389,11 +389,11 @@ describe("DelayModifier", async () => {
     });
 
     it("throws if transaction hashes do not match", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
-      await executor.setModule(modifier.address);
+      await avatar.setModule(modifier.address);
       await modifier.execTransactionFromModule(user1.address, 0, "0x", 0);
       let block = await hre.network.provider.send("eth_getBlockByNumber", [
         "latest",
@@ -407,11 +407,11 @@ describe("DelayModifier", async () => {
     });
 
     it("throws if transaction module transaction throws", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
-      await executor.setModule(modifier.address);
+      await avatar.setModule(modifier.address);
       await modifier.execTransactionFromModule(user1.address, 1, "0x", 0);
       let block = await hre.network.provider.send("eth_getBlockByNumber", [
         "latest",
@@ -425,11 +425,11 @@ describe("DelayModifier", async () => {
     });
 
     it("executes transaction", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
-      await executor.setModule(modifier.address);
+      await avatar.setModule(modifier.address);
       await modifier.execTransactionFromModule(user1.address, 0, "0x", 0);
       let block = await hre.network.provider.send("eth_getBlockByNumber", [
         "latest",
@@ -443,11 +443,11 @@ describe("DelayModifier", async () => {
 
   describe("skipExpired()", async () => {
     it("should skip to the next nonce that has not yet expired", async () => {
-      const { executor, modifier } = await setupTestWithTestExecutor();
+      const { avatar, modifier } = await setupTestWithTestAvatar();
       const tx = await modifier.populateTransaction.enableModule(user1.address);
-      await executor.exec(modifier.address, 0, tx.data);
+      await avatar.exec(modifier.address, 0, tx.data);
 
-      await executor.setModule(modifier.address);
+      await avatar.setModule(modifier.address);
       for (let i = 0; i < 3; i++) {
         await modifier.execTransactionFromModule(user1.address, 0, "0x", 0);
       }


### PR DESCRIPTION
Changes proposed on this proposal:
- `Executor` name has been changed to `Avatar` in tests, documentation, setup scripts, and contracts
- `TestExecutor` file changed to `TestAvatar`